### PR TITLE
[PKG-4871] 0.3.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,8 @@ test:
     - pip check
     # Test suite requires package to be built in place.
     - pip install -e .
-    - pytest lib/hmmlearn/tests -v  -k "not test_fit"
+    - pytest lib/hmmlearn/tests -v  --ignore="lib/hmmlearn/tests/test_gaussian_hmm.py"  # [osx and x86]
+    - pytest lib/hmmlearn/tests -v  # [not (osx and x86)]
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,8 @@ requirements:
     - scikit-learn >=0.16,!=0.22.0
     - numpy >=1.10
     - scipy >=0.19.0
+    # mkl variant pulls in intel-openmp which conflicts with llvm-openmp. i.e. force to use openblas variant of numpy, scipy, etc.
+    - blas=*=openblas  # [osx and x86_64]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,6 +59,9 @@ about:
   license_family: BSD
   license_file: LICENSE.txt
   summary: Hidden Markov Models in Python with scikit-learn like API.
+  description: |
+    hmmlearn is a set of algorithms for unsupervised learning and inference of Hidden Markov Models.
+    For supervised learning learning of HMMs and similar models see seqlearn.
   doc_url: https://hmmlearn.readthedocs.io/en/stable/
   dev_url: https://github.com/hmmlearn/hmmlearn
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,8 +42,8 @@ test:
   commands:
     - pip check
     # Test suite requires package to be built in place.
-    - python setup.py develop
-    - pytest lib/hmmlearn/tests
+    - pip install -e .
+    - pytest lib/hmmlearn/tests -v
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - setuptools
     - setuptools_scm >=3.3
     - pytest
+    - wheel
   run:
     - python
     - scikit-learn >=0.16,!=0.22.0
@@ -50,6 +51,7 @@ test:
     - pybind11 >=2.6
     - setuptools
     - setuptools_scm >=3.3
+    - wheel
 
 about:
   home: https://github.com/hmmlearn/hmmlearn

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,6 @@ requirements:
     - pybind11 >=2.6
     - setuptools
     - setuptools_scm >=3.3
-    - pytest
     - wheel
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ test:
     - pip check
     # Test suite requires package to be built in place.
     - pip install -e .
-    - pytest lib/hmmlearn/tests -v
+    - pytest lib/hmmlearn/tests -v  -k "not test_fit"
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hmmlearn" %}
-{% set version = "0.2.8" %}
+{% set version = "0.3.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,43 +7,49 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 696931e3dce6801cc9b78c629f543061dd7eb67a71155b03d1b39ea172a2a5f9
+  sha256: edaf485fdb1ea88da9ac642b2006c63d9950dd15d4d132f7205305d383e6f745
 
 build:
-  number: 1
-  skip: true  # [py<35]
+  number: 0
+  skip: true  # [py<38]
   script:
-    - {{ PYTHON }} setup.py build_ext
-    - {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv  # [unix]
-    - {{ PYTHON }} setup.py install --single-version-externally-managed --record record.txt  # [win]
+    - {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-build-isolation -vv
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - numpy                                  # [build_platform != target_platform]
-    - pybind11                               # [build_platform != target_platform]
     - {{ compiler('c') }}
     - {{ compiler("cxx") }}
   host:
     - pip
     - python
-    - numpy
     - pybind11 >=2.6
     - setuptools
-    - setuptools_scm
+    - setuptools_scm >=3.3
+    - pytest
   run:
     - python
-    - scikit-learn >=0.16
-    - {{ pin_compatible('numpy') }}
+    - scikit-learn >=0.16,!=0.22.0
+    - numpy >=1.10
     - scipy >=0.19.0
-    - setuptools
-    - matplotlib-base >=1.1.1
 
 test:
+  source_files:
+    - .
   imports:
     - hmmlearn
     - hmmlearn.tests
+  commands:
+    - pip check
+    # Test suite requires package to be built in place.
+    - python setup.py develop
+    - pytest lib/hmmlearn/tests
+  requires:
+    - pip
+    - pytest
+    - python
+    - pybind11 >=2.6
+    - setuptools
+    - setuptools_scm >=3.3
 
 about:
   home: https://github.com/hmmlearn/hmmlearn
@@ -52,7 +58,7 @@ about:
   license_file: LICENSE.txt
   summary: Hidden Markov Models in Python with scikit-learn like API.
   doc_url: https://hmmlearn.readthedocs.io/en/stable/
-  dev_url: https://hmmlearn.readthedocs.io/en/latest/
+  dev_url: https://github.com/hmmlearn/hmmlearn
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ test:
     - pip check
     # Test suite requires package to be built in place.
     - pip install -e .
-    - pytest lib/hmmlearn/tests -v  --ignore="lib/hmmlearn/tests/test_gaussian_hmm.py"  # [osx and x86]
+    - pytest lib/hmmlearn/tests -v  --ignore="lib/hmmlearn/tests/test_gaussian_hmm.py" --ignore="lib/hmmlearn/tests/test_gmm_hmm.py"  # [osx and x86]
     - pytest lib/hmmlearn/tests -v  # [not (osx and x86)]
   requires:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,3 +73,5 @@ extra:
   recipe-maintainers:
     - npavlovikj
     - njzjz
+  skip-lints:
+    - version_constraints_missing_whitespace

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,8 @@ build:
   skip: true  # [py<38]
   script:
     - {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-build-isolation -vv
+  missing_dso_whitelist:  # [s390x]
+    - '$RPATH/ld64.so.1'  # [s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,8 +47,7 @@ test:
     - pip check
     # Test suite requires package to be built in place.
     - pip install -e .
-    - pytest lib/hmmlearn/tests -v  --ignore="lib/hmmlearn/tests/test_gaussian_hmm.py" --ignore="lib/hmmlearn/tests/test_gmm_hmm.py"  # [osx and x86]
-    - pytest lib/hmmlearn/tests -v  # [not (osx and x86)]
+    - pytest lib/hmmlearn/tests -v
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,7 +66,7 @@ about:
   description: |
     hmmlearn is a set of algorithms for unsupervised learning and inference of Hidden Markov Models.
     For supervised learning learning of HMMs and similar models see seqlearn.
-  doc_url: https://hmmlearn.readthedocs.io/en/stable/
+  doc_url: https://hmmlearn.readthedocs.io/
   dev_url: https://github.com/hmmlearn/hmmlearn
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,24 +37,15 @@ requirements:
     - blas=*=openblas  # [osx and x86_64]
 
 test:
-  source_files:
-    - .
   imports:
     - hmmlearn
     - hmmlearn.tests
   commands:
     - pip check
-    # Test suite requires package to be built in place.
-    - pip install -e .
-    - pytest lib/hmmlearn/tests -v
+    - python -I -mpytest --pyargs hmmlearn.tests
   requires:
     - pip
     - pytest
-    - python
-    - pybind11 >=2.6
-    - setuptools
-    - setuptools_scm >=3.3
-    - wheel
 
 about:
   home: https://github.com/hmmlearn/hmmlearn

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,1 +1,0 @@
-xorg-x11-server-Xorg


### PR DESCRIPTION
hmmlearn 0.3.2 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4871]
- [Upstream repository](https://github.com/hmmlearn/hmmlearn)
- [Upstream changelog/diff](https://github.com/hmmlearn/hmmlearn/blob/0.3.2/CHANGES.rst)

### Explanation of changes:

- Forced `openblas` on osx-64 to prevent a segfault error.
- Added upstream tests. 
  - ~~The tests require the package to be built in place and editable, so it's currently being rebuilt in the test block. Please let me know if there's a better way to go about that.~~ Thanks to @lorepirri for finding a better way to run the tests.
- Added `$RPATH/ld64.so.1` to `missing_dso_whitelist` for s390x


[PKG-4871]: https://anaconda.atlassian.net/browse/PKG-4871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ